### PR TITLE
Add sentencepiece to requirements

### DIFF
--- a/inference/requirements.txt
+++ b/inference/requirements.txt
@@ -1,3 +1,4 @@
 deepspeed>=0.14.2
 transformers>=4.39.0
 huggingface_hub[hf_transfer]
+sentencepiece


### PR DESCRIPTION
It seems `LlamaTokenizer` requires `sentencepiece` as a dependency. This resolves an issue where fetching the Arctic tokenizer triggers the following issue:

```python
AutoTokenizer.from_pretrained("Snowflake/snowflake-arctic-instruct" , trust_remote_code=True)
```
-> 
```
ImportError: cannot import name 'LlamaTokenizer' from 'transformers.models.llama' 
```